### PR TITLE
Fix logo link to Microsoft Rx Codeplex

### DIFF
--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -167,7 +167,7 @@ layout: default
       <a href="http://github.com/" class="frontpage-logo github-logo"></a>
       <a href="http://www.couchbase.com/" class="frontpage-logo couchbase-logo"></a>
       <a href="http://soundcloud.com/" class="frontpage-logo soundcloud-logo"></a>
-      <a href="http://msdn.microsoft.com/en-us/data/gg577609.aspx" class="frontpage-logo microsoft-logo"></a>
+      <a href="http://rx.codeplex.com/" class="frontpage-logo microsoft-logo"></a>
       <a href="http://www.futurice.com" class="frontpage-logo futurice-logo"></a>
     </div>
   </div>


### PR DESCRIPTION
I assume the Microsoft's logo should go to http://rx.codeplex.com/ instead of http://msdn.microsoft.com/en-us/data/gg577609.aspx. But it's not up to me where exactly should this link take to.
