### PR TITLE
correcting two incorrectly copied marble diagrams

### DIFF
--- a/documentation/Operators/buffer.html
+++ b/documentation/Operators/buffer.html
@@ -256,7 +256,7 @@
       <li><code>rx.lite.extras.js</code></li>
      </ul>
      <figure class="variant">
-      <img src="IMAGES/buffer5.png" width="640" height="340" alt="bufferWithTime(timeSpan)" />
+      <img src="IMAGES/bufferWithTime5.png" width="640" height="340" alt="bufferWithTime(timeSpan)" />
       <figcaption>
        <p><code>bufferWithTime(timeSpan)</code> emits a new collection of items periodically, every
           <code>timeSpan</code> milliseconds, containing all items emitted by the source Observable
@@ -267,7 +267,7 @@
       </figcaption>
      </figure>
      <figure class="variant">
-      <img src="IMAGES/buffer7.png" width="640" height="320" alt="bufferWithTime(timeSpan,timeShift)" />
+      <img src="IMAGES/bufferWithTime7.png" width="640" height="320" alt="bufferWithTime(timeSpan,timeShift)" />
       <figcaption>
        <p><code>bufferWithTime(timeSpan,&#8239;timeShift)</code> creates a new collection of items
           every <code>timeShift</code> milliseconds, and fills this bundle with every item emitted


### PR DESCRIPTION
Updating two marble diagrams with the correct language-specific versions.
