### PR TITLE
Improved lang_operator plugin to accept description arg

### DIFF
--- a/_plugins/lang_operator.rb
+++ b/_plugins/lang_operator.rb
@@ -1,11 +1,12 @@
 module Jekyll
   class LangOperatorTag < Liquid::Block
     #include TemplateWrapper
-    def initialize(tag_name, title, tokens)
+    def initialize(tag_name, text, tokens)
       super
-      @title = title.strip!
+      @title = text.split(/\s+/)[0]
       @title = @title.gsub(".", "")
       @title = @title.gsub(" ", "")
+      @description = text.split(/\s+/)[1..-1].join(' ')
     end
 
     def render(context)
@@ -15,7 +16,7 @@ module Jekyll
         <div class=\"panel-heading\" role=\"tab\" id=\"heading#{@title}\">
           <h4 class=\"panel-title\">
             <a data-toggle=\"collapse\" data-parent=\"\#accordion\" href=\"\#collapse#{@title}\" aria-expanded=\"true\" aria-controls=\"collapse#{@title}\">
-              #{@title}
+              #{@title} <code>#{@description}</code>
             </a>
           </h4>
         </div>

--- a/documentation/operators/buffer.html
+++ b/documentation/operators/buffer.html
@@ -43,7 +43,7 @@ bundles rather than emitting the items one at a time
 <h2>Language-Specific Information:</h2>
 
 <div class="panel-group operators-by-language" id="accordion" role="tablist" aria-multiselectable="true">
-  {% lang_operator RxCpp %}
+  {% lang_operator RxCpp buffer(count), buffer(count, skip) %}
     <p>
     RxCpp implements two variants of <span class="operator">Buffer</span>:
     </p>


### PR DESCRIPTION
New usage `{% lang_operator RxCpp buffer(count), buffer(count, skip) %}`
Old usage `{% lang_operator %}`
