### PR TITLE
Fixed bug in finallyDo documentation

### DIFF
--- a/documentation/operators/do.html
+++ b/documentation/operators/do.html
@@ -267,7 +267,7 @@ Error: Item exceeds maximum value</pre></div>
     <figure class="variant">
      <img src="images/finallyDo.png" style="width:100%;" alt="finallyDo" />
      <figcaption><p>
-      The <code>doOnTerminate</code> operator registers an <code>Action</code> which will be called just
+      The <code>finallyDo</code> operator registers an <code>Action</code> which will be called just
       <em>after</em> the resulting Observable terminates, whether normally or with an error.
      </p>
      <ul>

--- a/documentation/operators/do.html
+++ b/documentation/operators/do.html
@@ -129,7 +129,7 @@ id: do
     <figure class="variant">
      <img src="images/finallyDo.png" style="width:100%;" alt="finallyDo" />
      <figcaption><p>
-      The <code>doOnTerminate</code> operator registers an <code>Action</code> which will be called just
+      The <code>finallyDo</code> operator registers an <code>Action</code> which will be called just
       <em>after</em> the resulting Observable terminates, whether normally or with an error.
      </p>
      <h4>Sample Code</h4>


### PR DESCRIPTION
`finallyDo` operator have similar description to `doOnTerminate` but documentation should refer to `finallyDo` instead of `doOnTerminate`
Corrected in RxJava and RxGroovy documentation.