### PR TITLE
Minor copy change for improved clarity

### DIFF
--- a/documentation/observable.markdown
+++ b/documentation/observable.markdown
@@ -108,9 +108,8 @@ myObservable.subscribe(myOnNext);
       the item emitted by the Observable.</dd>
  <dt><code>onError</code></dt>
   <dd>An Observable calls this method to indicate that it has failed to generate the expected data or has
-      encountered some other error. This stops the Observable and it will not make further calls to
-      <code>onNext</code> or <code>onCompleted</code>. The <code>onError</code> method takes as its parameter
-      an indication of what caused the error.</dd>
+      encountered some other error. It will not make further calls to <code>onNext</code> or <code>onCompleted</code>.
+      The <code>onError</code> method takes as its parameter an indication of what caused the error.</dd>
  <dt><code>onCompleted</code></dt>
   <dd>An Observable calls this method after it has called <code>onNext</code> for the final time, if it has not
       encountered any errors.</dd>


### PR DESCRIPTION
Recently several of my colleagues and I found the phrase "This
stops the Observable" to be misleading in the context of multiple
observers of an observable. While the observable stops with
respect to that observer, it may still call onNext for other
observers and so the Observable itself is arguably not stopped.
This confusion gave us the mistaken impression that an observable
needs to be recreated after termination, when in fact
resubscription can be sufficient. We didn't discover our mistake
until we encountered the retry operator, which would have been
useless under our original interpretation of the onError and
onCompleted methods.