### PR TITLE
Fix replay() doc: no need to call Publish on a ConnectableObservable

### DIFF
--- a/documentation/operators/replay.html
+++ b/documentation/operators/replay.html
@@ -246,10 +246,11 @@
      <img src="images/replay.f.png" style="width:100%;" alt="replay" />
      <figcaption><p>
       There is also a variety of <code>replay</code> that returns an ordinary Observable. These
-      variants take as a parameter a transformative function; this function accepts an item emitted
-      by the source Observable as its parameter, and returns an item to be emitted by the resulting
-      Observable. So really, this operator does not replay the source Observable but instead replays
-      the source Observable <em>as transformed</em> by this function.
+      variants take as a parameter a transformative function; this function will receive an Observable 
+      which can be subscribed to as many times as necessary without causing multiple subscriptions 
+      to the upstream Observable. The function then should return an Observable whose values will 
+      be emitted to the downstream subscriber. So really, this operator does not replay the source 
+      Observable but instead replays the source Observable <em>as transformed</em> by this function.
      </p><p>
       Variants of this variety of the <code>replay</code> operator permit you to set a maximum
       buffer size to limit the number of items <code>replay</code> will buffer and replay to
@@ -312,10 +313,11 @@
      <img src="images/replay.f.png" style="width:100%;" alt="replay" />
      <figcaption><p>
       There is also a variety of <code>replay</code> that returns an ordinary Observable. These
-      variants take as a parameter a transformative function; this function accepts an item emitted
-      by the source Observable as its parameter, and returns an item to be emitted by the resulting
-      Observable. So really, this operator does not replay the source Observable but instead replays
-      the source Observable <em>as transformed</em> by this function.
+      variants take as a parameter a transformative function; this function will receive an Observable 
+      which can be subscribed to as many times as necessary without causing multiple subscriptions 
+      to the upstream Observable. The function then should return an Observable whose values will 
+      be emitted to the downstream subscriber. So really, this operator does not replay the source 
+      Observable but instead replays the source Observable <em>as transformed</em> by this function.
      </p><p>
       Variants of this variety of the <code>replay</code> operator permit you to set a maximum
       buffer size to limit the number of items <code>replay</code> will buffer and replay to

--- a/documentation/operators/replay.html
+++ b/documentation/operators/replay.html
@@ -289,9 +289,7 @@
      <img src="images/replay.png" style="width:100%;" alt="replay" />
      <figcaption><p>
       In RxJava there is a variety of the <code>replay</code> operator that returns a connectable
-      Observable. You must <a href="publish.html"><span class="operator">Publish</span></a> this
-      connectable Observable before observers can subscribe to it, and then
-      <a href="connect.html"><span class="operator">Connect</span></a> to it in order to observe its
+      Observable. You must <a href="connect.html"><span class="operator">Connect</span></a> to it in order to observe its
       emissions.
      </p><p>
       Variants of this variety of the <code>replay</code> operator permit you to set a maximum


### PR DESCRIPTION
See #200.