### PR TITLE
Correction of publish(Func1()) documentation in Java

### DIFF
--- a/documentation/operators/publish.html
+++ b/documentation/operators/publish.html
@@ -85,9 +85,9 @@ id: publish
     <figure class="variant">
      <img src="images/publishConnect.f.png" style="width:100%;" alt="publish" />
      <figcaption><p>
-      There is also a variant that takes a function as a parameter. This function takes an emitted
-      item from the source Observable as a parameter and produces the item that will be emitted in
-      its place by the <code>ConnectableObservable</code>.
+      There is also a variant that takes a function as a parameter. This function takes as a parameter 
+      the <code>ConnectableObservable</code> that shares a single subscription to the underlying Observable sequence.
+      This function produces and returns a new Observable sequence.
      </p>
      <ul>
       <li>Javadoc: <a href="http://reactivex.io/RxJava/javadoc/rx/Observable.html#publish(rx.functions.Func1)"><code>publish(Func1)</code></a></li>


### PR DESCRIPTION
The original text explains that parameter function _Func1_ takes an emitted item as a parameter when in reality the parameter of the function Func1 is the ConnectableObservable version of the original Observable. See method signature:

```public final <R> Observable<R> publish(Func1<? super Observable<T>, ? extends Observable<R>> selector)```

Java documentation: https://github.com/ReactiveX/RxJava/blob/1.x/src/main/java/rx/Observable.java#L8135