### PR TITLE
Adding switchMap to the set of related operators

### DIFF
--- a/documentation/operators/flatmap.html
+++ b/documentation/operators/flatmap.html
@@ -295,7 +295,7 @@ Sequence complete</pre></div>
     </p>
   {% endlang_operator %}
 
-  {% lang_operator RxJS concatMap concatMapObserver flatMap flatMapFirst flatMapLatest flatMapObserver flatMapWithMaxConcurrency for forIn manySelect selectConcat selectConcatObserver selectMany selectManyObserver selectSwitch selectSwitchFirst selectWithMatchConcurrent %}
+  {% lang_operator RxJS concatMap concatMapObserver flatMap flatMapFirst flatMapLatest flatMapObserver flatMapWithMaxConcurrency for forIn manySelect selectConcat selectConcatObserver selectMany selectManyObserver selectSwitch selectSwitchFirst selectWithMatchConcurrent switchMap %}
 <!--
  TODO: flatMapFirst, flatMapWithMaxConcurrency, selectSwitchFirst, selectWithMaxConcurrent
  https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/flatmapfirst.md


### PR DESCRIPTION
RxJS documentation for flatMap was missing the switchMap operator in the list of related operators. I am adding switchMap because most of the other language that have it mention it some making sure RxJS is up to date.