### PR TITLE
fix takeLast link 404 on last.html

### DIFF
--- a/documentation/operators/last.html
+++ b/documentation/operators/last.html
@@ -30,7 +30,7 @@ id: last
     <li><a href="elementat.html"><span class="operator">ElementAt</span></a></li>
     <li><a href="first.html"><span class="operator">First</span></a></li>
     <li><a href="take.html"><span class="operator">Take</span></a></li>
-    <li><a href="takeLast.html"><span class="operator">TakeLast</span></a></li>
+    <li><a href="takelast.html"><span class="operator">TakeLast</span></a></li>
     <li><a href="http://www.introtorx.com/Content/v1.0.10621.0/07_Aggregation.html#Last"><cite>Introduction to Rx</cite>: Last</a></li>
     <li><a href="http://rxmarbles.com/#last">RxMarbles: <code>last</code></a></li>
    </ul>


### PR DESCRIPTION
fix broken takeLast link in [last.html](http://reactivex.io/documentation/operators/last.html) page 'See also' section. Points to [takeLast.html](http://reactivex.io/documentation/operators/takeLast.html), instead of [takelast.html](http://reactivex.io/documentation/operators/takelast.html) (case of L)

