### PR TITLE
Added Dockerfile for building & running the site using Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jekyll/jekyll:3.8.0
+FROM jekyll/jekyll
 WORKDIR /app
 
 RUN apk update && apk upgrade

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM jekyll/jekyll:3.8.0
+WORKDIR /app
+
+RUN apk update && apk upgrade
+RUN apk --no-cache add python
+
+RUN gem install uglifier pygments.rb redcarpet
+RUN npm install -g less
+
+EXPOSE 4000
+ENTRYPOINT rake

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ ReactiveX Website - [Jekyll](http://jekyllrb.com/) + [Bootstrap](http://getboots
 
 If you want to contribute, please make sure to make your changes to the **develop** branch, from which the master branch is generated.
 
+Use Docker to Build & Run (Optional)
+--------------
+If you have Docker installed, you can use the Dockerfile in this repository to build and run the ReactiveX website. This one-liner will perform the build and run:
+`docker build -t reactivex.io - < Dockerfile && docker run -p 4000:4000 -it --rm -v $PWD:/app -t reactivex.io`
+
 Install tools
 --------------
 


### PR DESCRIPTION
When I started on the reactivex.github.io project yesterday, I didn't have most of the requisite tools. By using a Docker image, I think new contributors will be able to start contributing faster (assuming they have Docker). This provides a certain degree of reproducibility as well, especially if we make the Dockerfile more restrictive to the versions of each required dependency.

If desired, I can add a docker-compose file or bash script to make the build & run command less verbose.