### PR TITLE
 fix wrong url in other language documentation side menu.

### DIFF
--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -24,7 +24,7 @@ layout: default
       <ul class="side-menu">
         <li><a href="{{ site.url }}/documentation/cn{{ page.url | replace_first:'/documentation','' | replace_first:'/ko','' | replace_first:'/cn','' }}">简体中文</a></li>
         <li><a href="{{ site.url }}/documentation/ko{{ page.url | replace_first:'/documentation','' | replace_first:'/ko','' | replace_first:'/cn','' }}">한국어</a></li>
-        <li><a href="{{ site.url }}/documentation{{ page.url | replace_first:'/documentation','' }}">English</a></li>
+        <li><a href="{{ site.url }}/documentation{{ page.url | replace_first:'/documentation','' | replace_first:'/ko','' | replace_first:'/cn','' }}">English</a></li>
       </ul>
 
       <ul class="side-menu">


### PR DESCRIPTION
http://reactivex.io/documentation/ko/observable.html

fix some misgenerated url 
( "/documentation/ko/observable.html" has to be "/documentation/observable.html")

![image](https://user-images.githubusercontent.com/12122155/50056772-a1a94480-01a4-11e9-94e5-b9c7b62ffc59.png)

![image](https://user-images.githubusercontent.com/12122155/50056769-8807fd00-01a4-11e9-9a35-dbdc07e56c29.png)
