### PR TITLE
Add required dependencies not listed in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ Install tools
 --------------
 
 Jekyll is the static site generator. Uglifier, LESS, and Rake are build tools necessary for JavaScript and CSS compilation prior to Jekyll.
+Pygments.rb is used for syntax highlighting and redcarpet is used as the markdown parser for Jekyll.
 
 ```
-$ gem install jekyll uglifier rake
+$ gem install jekyll uglifier rake pygments.rb redcarpet
 $ npm install -g less
 ```
 


### PR DESCRIPTION
When trying to build the site myself, I first had to install two additional gems not listed in the README:
- pygments.rb
- redcarpet

This PR adds them to the list of requirements in README.md.