### PR TITLE
Update Dockerfile to use jekyll:3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jekyll/jekyll
+FROM jekyll/jekyll:3.8
 WORKDIR /app
 
 RUN apk update && apk upgrade


### PR DESCRIPTION
Jekyll 4.0 dropped support for redcarpet which is currently used
as the markdown parser.

https://github.com/jekyll/jekyll/issues/7838

It may be better to migrate to jekyll:4 in the future, but this gets
the Dockerfile back into a working state.

Fixes #400 