### PR TITLE
Change the Markdown Converter.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ site/_site/
 coverage
 .ruby-version
 .sass-cache
+.jekyll-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 RUN apk update && apk upgrade
 RUN apk --no-cache add python
 
-RUN gem install uglifier pygments.rb redcarpet
+RUN gem install uglifier kramdown
 RUN npm install -g less
 
 EXPOSE 4000

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 name: ReactiveX
-markdown: redcarpet
-redcarpet:
-   extensions: ["no_intra_emphasis", "fenced_code_blocks", "autolink", "tables", "with_toc_data"]
-highlighter: pygments
+markdown: kramdown
+kramdown:
+   input: GFM
+highlighter: Rouge
 exclude: [TODO, Rakefile, bootstrap, styles]


### PR DESCRIPTION
The `redcarpet` gem was deprecated and now uses `kramdown,` which has been fixed.

How about this?