### PR TITLE
No need to track jekyll-cache.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ site/_site/
 coverage
 .ruby-version
 .sass-cache
+.jekyll-cache


### PR DESCRIPTION
Since `jekyll-cache` is generated during the build process, I see no need to track it.