### PR TITLE
Update takeuntil.html

### DIFF
--- a/documentation/operators/takeuntil.html
+++ b/documentation/operators/takeuntil.html
@@ -17,8 +17,8 @@ id: takeUntil
     <rx-marbles key="takeUntil"></rx-marbles>
     <figcaption><p>
      The <span class="operator">TakeUntil</span> subscribes and begins mirroring the source Observable. It also
-     monitors a second Observable that you provide. If this second Observable emits an item or sends a
-     termination notification, the Observable returned by <span class="operator">TakeUntil</span> stops
+     monitors a second Observable that you provide. If this second Observable emits an item or sends an
+     error event, the Observable returned by <span class="operator">TakeUntil</span> stops
      mirroring the source Observable and terminates.
     </p><p>
      In some ReactiveX implementations, <span class="operator">TakeUntil</span> will not stop mirroring


### PR DESCRIPTION
Clarify termination functionality. TakeUntil does not terminate if the second Observable completes without emitting a next event.