### PR TITLE
Add Julia to the list of languages

### DIFF
--- a/languages.markdown
+++ b/languages.markdown
@@ -26,6 +26,7 @@ id: languages
 * PHP: [RxPHP](https://github.com/ReactiveX/RxPHP)
 * Elixir: [reaxive](https://github.com/alfert/reaxive)
 * Dart: [RxDart](https://github.com/ReactiveX/rxdart)
+* Julia: [Rocket](https://github.com/ReactiveBayes/Rocket.jl)
 
 ## ReactiveX for platforms and frameworks
 


### PR DESCRIPTION
This PR adds Julia to the list of languages and references the [Rocket.jl](https://github.com/ReactiveBayes/Rocket.jl) library. Rocket.jl is the most starred Rx implementation in Julia and adheres to the same principles and naming conventions for operators and other functionalities.

Fixes #413 